### PR TITLE
#4 Add support multi-page in WordPress

### DIFF
--- a/src/Kunoichi/TocGenerator/Item.php
+++ b/src/Kunoichi/TocGenerator/Item.php
@@ -13,7 +13,7 @@ class Item {
 	/**
 	 * @var \DOMNode
 	 */
-	private $dom = null;
+	protected $dom = null;
 
 	/**
 	 * Item constructor.

--- a/src/Kunoichi/TocGenerator/Parser.php
+++ b/src/Kunoichi/TocGenerator/Parser.php
@@ -27,17 +27,21 @@ class Parser {
 
 	protected $title = '';
 
+	protected $item_class = '';
+
 	/**
 	 * Constructor
 	 *
 	 * @param int    $max_depth
 	 * @param bool   $ignore_deeper
 	 * @param string $id
+	 * @param string $item_class
 	 */
-	public function __construct( $max_depth = 3, $ignore_deeper = false, $id = 'content-section-' ) {
+	public function __construct( $max_depth = 3, $ignore_deeper = false, $id = 'content-section-', $item_class = Item::class ) {
 		$this->id_prefix     = $id;
 		$this->max_depth     = $max_depth;
 		$this->ignore_deeper = $ignore_deeper;
+		$this->item_class    = $item_class;
 	}
 
 	/**
@@ -95,7 +99,7 @@ class Parser {
 			if ( $this->ignore_deeper && ( (int) $level > $this->max_depth ) ) {
 				continue;
 			}
-			$items[] = new Item( $hn );
+			$items[] = new $this->item_class( $hn );
 		}
 		return $items;
 	}

--- a/src/Kunoichi/TocGenerator/WpItem.php
+++ b/src/Kunoichi/TocGenerator/WpItem.php
@@ -1,0 +1,76 @@
+<?php
+
+namespace Kunoichi\TocGenerator;
+
+/**
+ * Item for WordPress
+ *
+ * @package Kunoichi\TocGenerator
+ */
+class WpItem extends Item {
+
+	/**
+	 * Item constructor.
+	 *
+	 * @param \DOMNode $dom
+	 */
+	public function __construct( $dom ) {
+		parent::__construct( $dom );
+	}
+
+	/**
+	 * Get markup of contents.
+	 *
+	 * @return string
+	 */
+	public function get_markup() {
+		global $page;
+		$item_page = $this->page();
+
+		if ( $page !== $item_page ) {
+			// @see <a href="https://developer.wordpress.org/reference/functions/_wp_link_page/">_wp_link_page()</a>
+			global $wp_rewrite;
+			$post       = get_post();
+			$query_args = array();
+			$item_page  = $this->page();
+
+			if ( 1 === $item_page ) {
+				$url = get_permalink();
+			} else {
+				if ( ! get_option( 'permalink_structure' ) || in_array( get_post_status(), array(
+						'draft',
+						'pending'
+					), true ) ) {
+					$url = add_query_arg( 'page', $item_page, get_permalink() );
+				} elseif ( 'page' === get_option( 'show_on_front' ) && (int) get_option( 'page_on_front' ) === get_the_ID() ) {
+					$url = trailingslashit( get_permalink() ) . user_trailingslashit( "$wp_rewrite->pagination_base/" . $item_page, 'single_paged' );
+				} else {
+					$url = trailingslashit( get_permalink() ) . user_trailingslashit( $item_page, 'single_paged' );
+				}
+			}
+
+			if ( is_preview() ) {
+				if ( ( 'draft' !== $post->post_status ) && isset( $_GET['preview_id'], $_GET['preview_nonce'] ) ) {
+					$query_args['preview_id']    = wp_unslash( $_GET['preview_id'] );
+					$query_args['preview_nonce'] = wp_unslash( $_GET['preview_nonce'] );
+				}
+				$url = get_preview_post_link( $post, $query_args, $url );
+			}
+			$link = sprintf( '%s%s', $url, $this->href() );
+
+		} else {
+			$link = $this->href();
+		}
+
+		return sprintf( '<a href="%s" data-page="%s">%s</a>', esc_url( $link ), esc_attr( $item_page ), esc_html( $this->text() ) );
+	}
+
+	/**
+	 * Return page attributes
+	 *
+	 * @return int
+	 */
+	public function page() {
+		return (int) $this->dom->getAttribute( 'data-page' );
+	}
+}

--- a/src/Kunoichi/TocGenerator/WpParser.php
+++ b/src/Kunoichi/TocGenerator/WpParser.php
@@ -14,15 +14,18 @@ class WpParser extends Parser {
 
 	protected $done = false;
 
+	protected $page_counter = 0;
+
 	/**
 	 * Constructor
 	 *
 	 * @param int $max_depth
 	 * @param bool $ignore_deeper
 	 * @param string $id
+	 * @param string $item_class
 	 */
-	public function __construct( $max_depth = 3, $ignore_deeper = false, $id = 'content-section-' ) {
-		parent::__construct( $max_depth, $ignore_deeper, $id );
+	public function __construct( $max_depth = 3, $ignore_deeper = false, $id = 'content-section-', $item_class = WpItem::class ) {
+		parent::__construct( $max_depth, $ignore_deeper, $id, $item_class );
 		add_action( 'wp_head', [ $this, 'prepare' ] );
 		add_filter( 'the_content', [ $this, 'post_content' ] );
 		add_action( 'kunoichi_toc_generate', [ $this, 'generate' ], 10 );
@@ -56,7 +59,54 @@ class WpParser extends Parser {
 			$this->save_parsed_html( $content );
 			$this->done = true;
 		}
+
 		return $content;
+	}
+
+	/**
+	 * Add link id to html elements.
+	 *
+	 * @param string $html
+	 *
+	 * @return string
+	 */
+	public function add_link_html( $html ) {
+		$contents = preg_split( '/<!--nextpage-->/u', $html );
+		if ( is_array( $contents ) ) {
+			$replaced_html      = '';
+			$this->page_counter = 0;
+			foreach ( $contents as $content ) {
+				$this->counter = 0;
+				$this->page_counter ++;
+				$replaced_html .= preg_replace_callback( '/<(h[1-6])([^>]*?)>/u', [ $this, 'convert_link' ], $content );
+			}
+
+			return $replaced_html;
+		} else {
+			return preg_replace_callback( '/<(h[1-6])([^>]*?)>/u', [ $this, 'convert_link' ], $html );
+		}
+	}
+
+	/**
+	 * Add link to title elements.
+	 *
+	 * @param string[] $matches
+	 *
+	 * @return string
+	 */
+	protected function convert_link( $matches ) {
+		$this->counter ++;
+		$attributes = $matches[2];
+		if ( preg_match( '/id=\'|"([\'"]*)(\'|")/u', $matches[2], $id_matches ) ) {
+			$id = $id_matches[1];
+		} else {
+			$id         = sprintf( '%s%d', $this->id_prefix, $this->counter );
+			$attributes .= sprintf( ' id="%s"', $id ) . $matches[2];
+		}
+		// Add an attribute for the page number.
+		$attributes .= sprintf( ' data-page="%d"', $this->page_counter );
+
+		return sprintf( '<%s%s>', $matches[1], $attributes );
 	}
 
 	/**


### PR DESCRIPTION
- https://github.com/kuno1/toc-generator/issues/4

上記対応のプルリクになります。

目次のリンクが以下のような挙動になるよう調整を加えてみました。

- ページ区切りが存在する場合
  - 現在ページに見出しが含まれる目次項目は、ページ内の見出し位置へのアンカーリンクになる。
  - 現在ページに見出しが含まれない目次項目は、別ページの見出し位置へのアンカーリンクになる。
- ページ区切りが存在しない場合
  - 全ての目次項目はページ内の見出し位置へのアンカーリンクになる。（これまでと同じ）

また、各目次タグに下記のような `data-page` 属性を付与し、その目次が何ページ目に含まれるものか参照できるようにしてみました。
これは、現在ページに含まれない目次は js で非表示にしたい、といった場合に制御しやすくする狙いです。

```
<a href="https://example.com/sample-page/2/#content-section-1" data-page="2">2ページ目の見出し</a>
```

## 動作サンプル

3ページあるページの1ページ目を表示している場合。

- 1ページ目に含まれる目次項目はページ内アンカーリンク。
- 2、3ページ目に含まれる目次項目は別ページのアンカーリンク。

![multipage-sample1](https://github.com/user-attachments/assets/2179e9fa-8bff-41de-b080-c4fd9ac78f52)

3ページあるページの2ページ目を表示している場合。

- 2ページ目に含まれる目次項目はページ内アンカーリンク。
- 1、3ページ目に含まれる目次項目は別ページのアンカーリンク。

![multipage-sample2](https://github.com/user-attachments/assets/879adb82-707b-4b1f-ac39-c4a02dad0d72)


ページ区切りがないページを表示している場合。

- 全ての目次項目はページ内アンカーリンク。

![not-multipage-sample1](https://github.com/user-attachments/assets/9a3984dc-b235-4416-aeb9-374dfa05b84b)

